### PR TITLE
Fix EditTask bugs found in PE-D (For Reference)

### DIFF
--- a/src/main/java/manageezpz/commons/core/Messages.java
+++ b/src/main/java/manageezpz/commons/core/Messages.java
@@ -19,21 +19,19 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
 
-    public static final String MESSAGE_INVALID_TASK_TYPE = "Task is an invalid Task Type!";
-    public static final String MESSAGE_INVALID_TIME_FORMAT = "Invalid time format!";
-    public static final String MESSAGE_INVALID_TIME_RANGE =
-            "The time range you provided is invalid as end time should be after start time!";
-
     public static final String MESSAGE_DUPLICATE_TASK = "Task with the same description '%1$s' already exists! \n\n";
 
     public static final String MESSAGE_FIELD_NOT_EDITED = "At least one of the fields to edit must be provided.\n\n";
 
-    // Not used, will delete before end of V1.4
+    public static final String MESSAGE_INVALID_TIME_RANGE =
+            "The time range you provided is invalid as end time should be after start time!";
+
+    // Not used currently, will delete before end of V1.4
 
     public static final String MESSAGE_EMPTY_TASK_NUMBER = "Task number field cannot be empty! \n\n%1$s";
 
-    public static final String MESSAGE_TODO_SHOULD_NOT_HAVE_DATETIME = "Todo Task should not have date or time!";
-
     public static final String MESSAGE_EMPTY_START_TIME_END_TIME =
             "Please enter a start time and end time for the event!";
+
+    public static final String MESSAGE_INVALID_TIME_FORMAT = "Invalid time format!";
 }


### PR DESCRIPTION
Here are the bug fixes to the EditTask issues found in PE-D.

#212 & #215 - Added extra checks for empty values after `desc/`, `date/` and `at/`

![Issue 212_01](https://user-images.githubusercontent.com/6387754/161832500-10d6a10c-4768-435b-8515-8707bcf2768f.png)

![Issue 212_02](https://user-images.githubusercontent.com/6387754/161832506-5b4f4bbb-da82-4477-a622-b5a8dcc16907.png)

![Issue 212_03](https://user-images.githubusercontent.com/6387754/161832510-b0cf180c-3737-4ae8-a7b6-e58ebed1aca9.png)

#228 - Added extra checks when date is entered for Todo task

![Issue 228](https://user-images.githubusercontent.com/6387754/161835592-52bd57fe-61ec-47c5-9395-08ae449071bf.png)

#235 - Added extra checks when time is entered for Todo task

![Issue 235_01](https://user-images.githubusercontent.com/6387754/161835657-bc627e6f-7884-44f5-bf7f-bf3f0fb7e2b6.png)

![Issue 235_02](https://user-images.githubusercontent.com/6387754/161835868-33a6a194-7137-4983-a4dc-a702d7d37338.png)