### PR TITLE
Bug fix related to Edit Task

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -241,15 +241,16 @@ Formats:
 
 Editing tasks is flexible in ManageEZPZ.
 For example, you can update just the task description or perhaps
-just the date and time of the task only.
-However, you are not allowed to edit a task with no prefix supplied.
-Either `desc/NAME`, `date/DATE` or `at/TIME` must have a value.
+just the date and time of the task only. <br/>
+However, you are not allowed to edit a task with no prefix supplied or if you have supplied a prefix, 
+a corresponding input after the prefix must exist. <br/>
+Either one of `desc/NAME`, `date/DATE` or `at/TIME` must exist.
 
 <b>Note:</b> 
 * For deadline and event, any TIME related fields must be in the format HHmm, where HH should only be between 00 and 23
   and mm should only be between 00 and 59.
-* When supplying empty NAME, DATE or TIME, it will not change the state of the Task.
-
+* For todo, you are not allowed to use `date/DATE` and/or `at/TIME` as it does not have a date 
+and time field to be edited.
 
 Examples: <br/>
 

--- a/src/main/java/manageezpz/commons/core/Messages.java
+++ b/src/main/java/manageezpz/commons/core/Messages.java
@@ -10,7 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT_BIND = "Invalid command format! \n\n%1$s";
 
     public static final String MESSAGE_EMPTY_NAME = "Name field cannot be empty! \n\n%1$s";
-    public static final String MESSAGE_EMPTY_DESCRIPTION = "Description cannot be empty!";
     public static final String MESSAGE_EDIT_TASK_NO_EMPTY_VALUES =
             "Either desc/ date/ or at/ must have a value after it!";
     public static final String MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES =

--- a/src/main/java/manageezpz/commons/core/Messages.java
+++ b/src/main/java/manageezpz/commons/core/Messages.java
@@ -10,7 +10,11 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT_BIND = "Invalid command format! \n\n%1$s";
 
     public static final String MESSAGE_EMPTY_NAME = "Name field cannot be empty! \n\n%1$s";
-    public static final String MESSAGE_EMPTY_DESCRIPTION = "Description cannot be empty! \n\n%1$s";
+    public static final String MESSAGE_EMPTY_DESCRIPTION = "Description cannot be empty!";
+    public static final String MESSAGE_EDIT_TASK_NO_EMPTY_VALUES
+            = "Either desc/ date/ or at/ must have a value after it!";
+    public static final String MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES
+            = "A todo task does not have a date or time to be edited!";
 
 
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =

--- a/src/main/java/manageezpz/commons/core/Messages.java
+++ b/src/main/java/manageezpz/commons/core/Messages.java
@@ -10,6 +10,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT_BIND = "Invalid command format! \n\n%1$s";
 
     public static final String MESSAGE_EMPTY_NAME = "Name field cannot be empty! \n\n%1$s";
+    public static final String MESSAGE_EMPTY_DESCRIPTION = "Description cannot be empty! \n\n%1$s";
+
 
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
             "The person index provided is invalid as it exceeds the amount of persons in the displayed list! \n\n%1$s";

--- a/src/main/java/manageezpz/commons/core/Messages.java
+++ b/src/main/java/manageezpz/commons/core/Messages.java
@@ -11,12 +11,10 @@ public class Messages {
 
     public static final String MESSAGE_EMPTY_NAME = "Name field cannot be empty! \n\n%1$s";
     public static final String MESSAGE_EMPTY_DESCRIPTION = "Description cannot be empty!";
-    public static final String MESSAGE_EDIT_TASK_NO_EMPTY_VALUES
-            = "Either desc/ date/ or at/ must have a value after it!";
-    public static final String MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES
-            = "A todo task does not have a date or time to be edited!";
-
-
+    public static final String MESSAGE_EDIT_TASK_NO_EMPTY_VALUES =
+            "Either desc/ date/ or at/ must have a value after it!";
+    public static final String MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES =
+            "A todo task does not have a date or time to be edited!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
             "The person index provided is invalid as it exceeds the amount of persons in the displayed list! \n\n%1$s";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX =

--- a/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
+++ b/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
@@ -1,11 +1,7 @@
 package manageezpz.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static manageezpz.commons.core.Messages.MESSAGE_DUPLICATE_TASK;
-import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
-import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_TYPE;
-import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TIME_FORMAT;
-import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TIME_RANGE;
+import static manageezpz.commons.core.Messages.*;
 import static manageezpz.commons.util.CollectionUtil.requireAllNonNull;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_AT_DATETIME;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_DATE;
@@ -65,6 +61,7 @@ public class EditTaskCommand extends Command {
     private final String desc;
     private final String date;
     private final String time;
+    private final boolean[] prefixStatusArr;
 
     /**
      * Constructor to initialize an instance of EditTaskCommand class
@@ -76,12 +73,13 @@ public class EditTaskCommand extends Command {
      * @param date New date of the Task
      * @param time New time of the Task
      */
-    public EditTaskCommand(Index index, String desc, String date, String time) {
+    public EditTaskCommand(Index index, String desc, String date, String time, boolean[] prefixStatusArr) {
         requireAllNonNull(index, desc, date, time);
         this.index = index;
         this.desc = desc;
         this.date = date;
         this.time = time;
+        this.prefixStatusArr = prefixStatusArr;
     }
 
     @Override
@@ -120,10 +118,15 @@ public class EditTaskCommand extends Command {
 
     private Task updateTodo(Todo currentTask, String desc) throws ParseException {
         Todo updatedToDoTask = new Todo(currentTask);
+        if (prefixStatusArr[1] || prefixStatusArr[2]) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+        }
 
         if (!desc.isEmpty()) {
             Description newDesc = ParserUtil.parseDescription(desc);
             updatedToDoTask.setDescription(newDesc);
+        } else {
+            throw new ParseException(MESSAGE_EMPTY_DESCRIPTION);
         }
 
         return updatedToDoTask;

--- a/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
+++ b/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
@@ -9,7 +9,6 @@ import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_IN
 import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_TYPE;
 import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TIME_FORMAT;
 import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TIME_RANGE;
-import static manageezpz.commons.util.CollectionUtil.requireAllNonNull;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_AT_DATETIME;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_DATE;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_DESCRIPTION;

--- a/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
+++ b/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
@@ -1,7 +1,14 @@
 package manageezpz.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static manageezpz.commons.core.Messages.*;
+import static manageezpz.commons.core.Messages.MESSAGE_DUPLICATE_TASK;
+import static manageezpz.commons.core.Messages.MESSAGE_EDIT_TASK_NO_EMPTY_VALUES;
+import static manageezpz.commons.core.Messages.MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES;
+import static manageezpz.commons.core.Messages.MESSAGE_EMPTY_DESCRIPTION;
+import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
+import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_TYPE;
+import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TIME_FORMAT;
+import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TIME_RANGE;
 import static manageezpz.commons.util.CollectionUtil.requireAllNonNull;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_AT_DATETIME;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_DATE;
@@ -15,7 +22,13 @@ import manageezpz.logic.commands.exceptions.CommandException;
 import manageezpz.logic.parser.ParserUtil;
 import manageezpz.logic.parser.exceptions.ParseException;
 import manageezpz.model.Model;
-import manageezpz.model.task.*;
+import manageezpz.model.task.Date;
+import manageezpz.model.task.Deadline;
+import manageezpz.model.task.Description;
+import manageezpz.model.task.Event;
+import manageezpz.model.task.Task;
+import manageezpz.model.task.Time;
+import manageezpz.model.task.Todo;
 import manageezpz.model.task.exceptions.DuplicateTaskException;
 
 /**
@@ -68,8 +81,8 @@ public class EditTaskCommand extends Command {
      * @param date New date of the Task
      * @param time New time of the Task
      */
-    public EditTaskCommand(Index index, String desc, String date, String time, HashMap<String, Boolean> prefixStatusHash) {
-        requireAllNonNull(index, desc, date, time);
+    public EditTaskCommand(Index index, String desc, String date, String time,
+                           HashMap<String, Boolean> prefixStatusHash) {
         this.index = index;
         this.desc = desc;
         this.date = date;
@@ -136,6 +149,14 @@ public class EditTaskCommand extends Command {
         return isFormatOkay;
     }
 
+    /**
+     * Updates a Todo task.
+     *
+     * @param currentTask Current Todo task that is to be updated
+     * @param desc New description of the Todo Task
+     * @return Updated Todo task
+     */
+
     private Task updateTodo(Todo currentTask, String desc) throws ParseException {
         Todo updatedToDoTask = new Todo(currentTask);
         if (prefixStatusHash.get("date") || prefixStatusHash.get("datetime")) {
@@ -151,6 +172,16 @@ public class EditTaskCommand extends Command {
 
         return updatedToDoTask;
     }
+
+    /**
+     * Updates a Deadline task.
+     *
+     * @param currentTask Current Deadline task that is to be updated
+     * @param desc New description of the Deadline Task
+     * @param date New date of the Deadline Task
+     * @param time New time of the Deadline Task
+     * @return Updated Deadline task
+     */
 
     private Task updateDeadline(Deadline currentTask, String desc, String date, String time) throws ParseException {
         Deadline updatedDeadlineTask = new Deadline(currentTask);
@@ -176,6 +207,17 @@ public class EditTaskCommand extends Command {
 
         return updatedDeadlineTask;
     }
+
+    /**
+     * Updates an Event task.
+     *
+     * @param currentTask Current Event task that is to be updated
+     * @param desc New description of the Event Task
+     * @param date New date of the Event Task
+     * @param startTime New start time of the Event Task
+     * @param endTime New end time of the Event Task
+     * @return Updated Event task
+     */
 
     private Task updateEvent(Event currentTask, String desc, String date, String time) throws ParseException {
         Event updatedEventTask = new Event(currentTask);

--- a/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
+++ b/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static manageezpz.commons.core.Messages.MESSAGE_DUPLICATE_TASK;
 import static manageezpz.commons.core.Messages.MESSAGE_EDIT_TASK_NO_EMPTY_VALUES;
 import static manageezpz.commons.core.Messages.MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES;
-import static manageezpz.commons.core.Messages.MESSAGE_EMPTY_DESCRIPTION;
 import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TASK_TYPE;
 import static manageezpz.commons.core.Messages.MESSAGE_INVALID_TIME_FORMAT;

--- a/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
+++ b/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
@@ -101,7 +101,6 @@ public class EditTaskCommand extends Command {
                 // Should not reach this as there are only three types of tasks
                 throw new CommandException(MESSAGE_INVALID_TASK_TYPE);
             }
-
             model.setTask(currentTask, updatedTask);
             return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, updatedTask));
         } catch (ParseException pe) {
@@ -110,6 +109,11 @@ public class EditTaskCommand extends Command {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_TASK, this.desc) + MESSAGE_USAGE);
         }
     }
+
+    /**
+     * If the value after a prefix is empty, return false.
+     * Else, return true.
+     */
 
     boolean ensureFormatCompliance(HashMap<String, Boolean> prefixStatusHash,
                                    String desc, String date, String time) {
@@ -134,7 +138,7 @@ public class EditTaskCommand extends Command {
 
     private Task updateTodo(Todo currentTask, String desc) throws ParseException {
         Todo updatedToDoTask = new Todo(currentTask);
-        if (prefixStatusHash.get("date") || prefixStatusHash.get("datetime") ) {
+        if (prefixStatusHash.get("date") || prefixStatusHash.get("datetime")) {
             throw new ParseException(MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES);
         }
 

--- a/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
+++ b/src/main/java/manageezpz/logic/commands/EditTaskCommand.java
@@ -118,7 +118,7 @@ public class EditTaskCommand extends Command {
         } catch (ParseException pe) {
             throw new CommandException(pe.getMessage() + "\n\n" + EditTaskCommand.MESSAGE_USAGE, pe);
         } catch (DuplicateTaskException de) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_TASK, this.desc) + MESSAGE_USAGE);
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_TASK, this.desc) + MESSAGE_USAGE, de);
         }
     }
 
@@ -127,7 +127,7 @@ public class EditTaskCommand extends Command {
      * Else, return true.
      */
 
-    boolean ensureFormatCompliance(HashMap<String, Boolean> prefixStatusHash,
+    private boolean ensureFormatCompliance(HashMap<String, Boolean> prefixStatusHash,
                                    String desc, String date, String time) {
         boolean isFormatOkay = true;
         HashMap<String, String> inputStatusHash = new HashMap<>();
@@ -162,12 +162,8 @@ public class EditTaskCommand extends Command {
             throw new ParseException(MESSAGE_EDIT_TODO_TASK_NO_DATE_AND_TIME_VALUES);
         }
 
-        if (!desc.isEmpty()) {
-            Description newDesc = ParserUtil.parseDescription(desc);
-            updatedToDoTask.setDescription(newDesc);
-        } else {
-            throw new ParseException(MESSAGE_EMPTY_DESCRIPTION);
-        }
+        Description newDesc = ParserUtil.parseDescription(desc);
+        updatedToDoTask.setDescription(newDesc);
 
         return updatedToDoTask;
     }

--- a/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
+++ b/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
@@ -6,12 +6,13 @@ import static manageezpz.logic.parser.CliSyntax.PREFIX_AT_DATETIME;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_DATE;
 import static manageezpz.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 
+import java.util.HashMap;
+
 import manageezpz.commons.core.index.Index;
 import manageezpz.logic.commands.EditTaskCommand;
 import manageezpz.logic.parser.exceptions.ParseException;
 
-import java.util.Arrays;
-import java.util.HashMap;
+
 
 /**
  * Parses input arguments and creates a new EditTaskCommand object.
@@ -22,7 +23,7 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
      * Parses the given {@code String} of arguments in the context of the EditTaskCommand
      * and returns a EditTaskCommand object for execution.
      *
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform to the expected format
      */
     @Override
     public EditTaskCommand parse(String args) throws ParseException {

--- a/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
+++ b/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
@@ -10,6 +10,8 @@ import manageezpz.commons.core.index.Index;
 import manageezpz.logic.commands.EditTaskCommand;
 import manageezpz.logic.parser.exceptions.ParseException;
 
+import java.util.Arrays;
+
 /**
  * Parses input arguments and creates a new EditTaskCommand object.
  */
@@ -49,7 +51,30 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
         String desc = argMultimap.getValue(PREFIX_DESCRIPTION).orElse("");
         String date = argMultimap.getValue(PREFIX_DATE).orElse("");
         String time = argMultimap.getValue(PREFIX_AT_DATETIME).orElse("");
+        boolean[] prefixStatusArr = prefixStatusCheck(argMultimap);
 
-        return new EditTaskCommand(index, desc, date, time);
+        for (int i  = 0; i < prefixStatusArr.length; i++){
+            System.out.println(prefixStatusArr[i]);
+        }
+
+        return new EditTaskCommand(index, desc, date, time, prefixStatusArr);
+    }
+
+    private boolean[] prefixStatusCheck (ArgumentMultimap argMultimap) {
+        boolean[] prefixStatusArr = new boolean[3];
+        Arrays.fill(prefixStatusArr, true);
+        if (argMultimap.getValue(PREFIX_DESCRIPTION).isEmpty()) {
+            prefixStatusArr[0] = false;
+        }
+
+        if (argMultimap.getValue(PREFIX_DATE).isEmpty()) {
+            prefixStatusArr[1] = false;
+        }
+
+        if (argMultimap.getValue(PREFIX_AT_DATETIME).isEmpty()) {
+            prefixStatusArr[2] = false;
+        }
+
+        return prefixStatusArr;
     }
 }

--- a/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
+++ b/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
@@ -54,9 +54,13 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
         String time = argMultimap.getValue(PREFIX_AT_DATETIME).orElse("");
         HashMap<String, Boolean> prefixStatusHash = prefixStatusCheck(argMultimap);
 
-
         return new EditTaskCommand(index, desc, date, time, prefixStatusHash);
     }
+
+    /**
+     * Initialize a hashmap that contains the status of a prefix.
+     * By status, it means whether a prefix has been inputted by a user or not.
+     */
 
     private HashMap<String, Boolean> initPrefixStatusHash() {
         HashMap<String, Boolean> prefixStatusHash = new HashMap<>();
@@ -65,6 +69,14 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
         prefixStatusHash.put("datetime", true);
         return prefixStatusHash;
     }
+
+    /**
+     * Check if a prefix has been inputted by a user or not.
+     * If yes, the boolean value of the corresponding prefix is true.
+     * Else, it is false.
+     * Note that it only checks if the prefix has been inputted.
+     * It does not check if there's a value attached to the prefix.
+     */
 
     private HashMap<String, Boolean> prefixStatusCheck (ArgumentMultimap argMultimap) {
         HashMap<String, Boolean> prefixStatusHash = initPrefixStatusHash();

--- a/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
+++ b/src/main/java/manageezpz/logic/parser/EditTaskCommandParser.java
@@ -11,6 +11,7 @@ import manageezpz.logic.commands.EditTaskCommand;
 import manageezpz.logic.parser.exceptions.ParseException;
 
 import java.util.Arrays;
+import java.util.HashMap;
 
 /**
  * Parses input arguments and creates a new EditTaskCommand object.
@@ -51,30 +52,34 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
         String desc = argMultimap.getValue(PREFIX_DESCRIPTION).orElse("");
         String date = argMultimap.getValue(PREFIX_DATE).orElse("");
         String time = argMultimap.getValue(PREFIX_AT_DATETIME).orElse("");
-        boolean[] prefixStatusArr = prefixStatusCheck(argMultimap);
+        HashMap<String, Boolean> prefixStatusHash = prefixStatusCheck(argMultimap);
 
-        for (int i  = 0; i < prefixStatusArr.length; i++){
-            System.out.println(prefixStatusArr[i]);
-        }
 
-        return new EditTaskCommand(index, desc, date, time, prefixStatusArr);
+        return new EditTaskCommand(index, desc, date, time, prefixStatusHash);
     }
 
-    private boolean[] prefixStatusCheck (ArgumentMultimap argMultimap) {
-        boolean[] prefixStatusArr = new boolean[3];
-        Arrays.fill(prefixStatusArr, true);
+    private HashMap<String, Boolean> initPrefixStatusHash() {
+        HashMap<String, Boolean> prefixStatusHash = new HashMap<>();
+        prefixStatusHash.put("description", true);
+        prefixStatusHash.put("date", true);
+        prefixStatusHash.put("datetime", true);
+        return prefixStatusHash;
+    }
+
+    private HashMap<String, Boolean> prefixStatusCheck (ArgumentMultimap argMultimap) {
+        HashMap<String, Boolean> prefixStatusHash = initPrefixStatusHash();
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isEmpty()) {
-            prefixStatusArr[0] = false;
+            prefixStatusHash.replace("description", false);
         }
 
         if (argMultimap.getValue(PREFIX_DATE).isEmpty()) {
-            prefixStatusArr[1] = false;
+            prefixStatusHash.replace("date", false);
         }
 
         if (argMultimap.getValue(PREFIX_AT_DATETIME).isEmpty()) {
-            prefixStatusArr[2] = false;
+            prefixStatusHash.replace("datetime", false);
         }
 
-        return prefixStatusArr;
+        return prefixStatusHash;
     }
 }


### PR DESCRIPTION
For Todo
 - Task no longer updates when description is empty. 
 - If date/ or at/ is detected, an exception is thrown.

For Event&Deadline:
- If a prefix (desc/ date/ at/) is declared, a corresponding value must be supplied. Otherwise, an exception is thrown.
